### PR TITLE
Add new technical indicators: RSI, MACD, Bollinger Bands, and ATR

### DIFF
--- a/indicators/atr.go
+++ b/indicators/atr.go
@@ -1,0 +1,68 @@
+package indicators
+
+import "math"
+
+// maxOfThree returns the maximum of three float64 numbers.
+func maxOfThree(a, b, c float64) float64 {
+	// Simpler way to write max for three numbers
+	return math.Max(a, math.Max(b, c))
+}
+
+// ATR calculates the Average True Range.
+func ATR(high []float64, low []float64, close []float64, period int) []float64 {
+	dataLen := len(high)
+
+	// 1. Input Validation
+	if len(low) != dataLen || len(close) != dataLen {
+		// Panic or return error. For now, return empty slice as per instruction.
+		// Consider logging this event in a real application.
+		return []float64{}
+	}
+	if dataLen == 0 {
+		return []float64{}
+	}
+	if period <= 0 {
+		return []float64{}
+	}
+	if dataLen < period {
+		// Return a slice of zeros with the same length as high.
+		return make([]float64, dataLen)
+	}
+
+	// Initialize ATR result slice, all elements default to 0.0
+	atr := make([]float64, dataLen)
+	tr := make([]float64, dataLen)
+
+	// 2. Calculate True Range (TR)
+	// TR[0] = high[0] - low[0]
+	if dataLen > 0 { // Should always be true due to earlier checks, but good for safety
+		tr[0] = high[0] - low[0]
+	}
+
+	for i := 1; i < dataLen; i++ {
+		val1 := high[i] - low[i]
+		val2 := math.Abs(high[i] - close[i-1])
+		val3 := math.Abs(low[i] - close[i-1])
+		tr[i] = maxOfThree(val1, val2, val3)
+	}
+
+	// 3. Calculate ATR using Wilder's Smoothing
+	// Calculate the first ATR value: average of the first 'period' TRs.
+	// This value is stored at atr[period-1].
+	var sumTR float64
+	for i := 0; i < period; i++ {
+		sumTR += tr[i]
+	}
+	if period > 0 { // Should be true due to earlier check
+	    atr[period-1] = sumTR / float64(period)
+	}
+
+
+	// Calculate subsequent ATR values using Wilder's smoothing.
+	// atr[0] to atr[period-2] remain 0.0.
+	for i := period; i < dataLen; i++ {
+		atr[i] = (atr[i-1]*float64(period-1) + tr[i]) / float64(period)
+	}
+
+	return atr
+}

--- a/indicators/bollinger_bands.go
+++ b/indicators/bollinger_bands.go
@@ -1,0 +1,55 @@
+package indicators
+
+import "math"
+
+// BollingerBandsResult holds the Upper Band, Middle Band, and Lower Band.
+type BollingerBandsResult struct {
+	UpperBand  []float64
+	MiddleBand []float64
+	LowerBand  []float64
+}
+
+// BollingerBands calculates the Bollinger Bands for a given dataset.
+// It uses SMA for the middle band and RollingStd for the standard deviation.
+func BollingerBands(data []float64, period int, numStdDev float64) BollingerBandsResult {
+	dataLen := len(data)
+	result := BollingerBandsResult{
+		UpperBand:  make([]float64, dataLen),
+		MiddleBand: make([]float64, dataLen),
+		LowerBand:  make([]float64, dataLen),
+	}
+
+	// Handle edge cases: invalid period, numStdDev, or empty data
+	if period <= 0 || numStdDev <= 0 || dataLen == 0 {
+		// Return zero-filled result, which is already the case
+		return result
+	}
+
+	// 1. Calculate the Middle Band (SMA)
+	// SMA is expected to return a slice of length dataLen, with leading zeros if len(data) < period.
+	middleBand := SMA(data, period)
+	copy(result.MiddleBand, middleBand) // Store SMA in the result
+
+	// 2. Calculate the Rolling Standard Deviation
+	// RollingStd is expected to return a slice of length dataLen.
+	// It uses math.NaN() for initial undefined values.
+	rollingStdDev := RollingStd(data, period)
+
+	// 3. & 4. Calculate Upper and Lower Bands
+	for i := 0; i < dataLen; i++ {
+		// If MiddleBand[i] is 0.0 (from SMA, indicating not enough data yet)
+		// or if RollingStd[i] is NaN, then Upper and Lower bands should be 0.0.
+		// MiddleBand[i] is already set from SMA.
+		if result.MiddleBand[i] == 0.0 || math.IsNaN(rollingStdDev[i]) {
+			result.UpperBand[i] = 0.0
+			result.LowerBand[i] = 0.0
+			// result.MiddleBand[i] is already 0.0 if SMA returned 0.0
+		} else {
+			stdDevVal := numStdDev * rollingStdDev[i]
+			result.UpperBand[i] = result.MiddleBand[i] + stdDevVal
+			result.LowerBand[i] = result.MiddleBand[i] - stdDevVal
+		}
+	}
+
+	return result
+}

--- a/indicators/macd.go
+++ b/indicators/macd.go
@@ -1,0 +1,60 @@
+package indicators
+
+// MACDResult holds the MACD Line, Signal Line, and Histogram.
+type MACDResult struct {
+	MACDLine   []float64
+	SignalLine []float64
+	Histogram  []float64
+}
+
+// MACD calculates the Moving Average Convergence Divergence.
+// It assumes an EMA function `func EMA(data []float64, period int) []float64` is available in the same package.
+func MACD(data []float64, fastPeriod int, slowPeriod int, signalPeriod int) MACDResult {
+	dataLen := len(data)
+	result := MACDResult{
+		MACDLine:   make([]float64, dataLen), // Initialized to 0.0 by default
+		SignalLine: make([]float64, dataLen), // Initialized to 0.0 by default
+		Histogram:  make([]float64, dataLen), // Initialized to 0.0 by default
+	}
+
+	// Edge Case: If input data is empty, or periods are invalid.
+	// fastPeriod < slowPeriod is a requirement.
+	// EMA function is expected to handle short data for its period by returning zero-padded slices.
+	// If periods are invalid (e.g., <=0), EMA should return zero-padded slices.
+	// We'll add a check for invalid periods or if fastPeriod >= slowPeriod for robustness.
+	if dataLen == 0 || fastPeriod <= 0 || slowPeriod <= 0 || signalPeriod <= 0 || fastPeriod >= slowPeriod {
+		// Return the zero-filled result, which is already the case.
+		return result
+	}
+
+	// 1. Calculate Fast EMA
+	fastEMA := EMA(data, fastPeriod)
+
+	// 2. Calculate Slow EMA
+	slowEMA := EMA(data, slowPeriod)
+
+	// Ensure EMA returned slices of the correct length.
+	// If not, it indicates an issue with the EMA function or assumptions.
+	// For now, we assume EMA behaves as specified (returns same length slice, zero-padded).
+
+	// 3. Calculate MACD Line: MACDLine[i] = fastEMA[i] - slowEMA[i]
+	// Since fastEMA and slowEMA are zero-padded, MACDLine will also be correctly zero-padded.
+	for i := 0; i < dataLen; i++ {
+		result.MACDLine[i] = fastEMA[i] - slowEMA[i]
+	}
+
+	// 4. Calculate Signal Line: EMA of the MACD Line, using signalPeriod.
+	// The EMA function will correctly handle leading zeros in result.MACDLine.
+	result.SignalLine = EMA(result.MACDLine, signalPeriod)
+	
+	// Ensure SignalLine is of the correct length.
+	// Assuming EMA behaves as specified.
+
+	// 5. Calculate Histogram: Histogram[i] = MACDLine[i] - SignalLine[i]
+	// This will also correctly propagate leading zeros.
+	for i := 0; i < dataLen; i++ {
+		result.Histogram[i] = result.MACDLine[i] - result.SignalLine[i]
+	}
+
+	return result
+}

--- a/indicators/rsi.go
+++ b/indicators/rsi.go
@@ -1,0 +1,78 @@
+package indicators
+
+import "math"
+
+// RSI calculates the Relative Strength Index.
+func RSI(data []float64, period int) []float64 {
+	rsiValues := make([]float64, len(data)) // Initialized to 0.0 by default
+
+	if period <= 0 || len(data) < period {
+		// Return a slice of zeros, which is already the state of rsiValues
+		return rsiValues
+	}
+
+	gains := make([]float64, len(data))
+	losses := make([]float64, len(data))
+
+	// Calculate price changes, gains, and losses
+	// Price changes start from data[1] - data[0], so gains/losses are stored from index 1.
+	for i := 1; i < len(data); i++ {
+		change := data[i] - data[i-1]
+		if change > 0 {
+			gains[i] = change
+			losses[i] = 0.0
+		} else if change < 0 {
+			gains[i] = 0.0
+			losses[i] = math.Abs(change)
+		} else {
+			gains[i] = 0.0
+			losses[i] = 0.0
+		}
+	}
+
+	// Calculate initial average gain and loss for the first 'period'
+	var sumGains float64
+	var sumLosses float64
+	// The first 'period' price changes are from gains[1]/losses[1] to gains[period]/losses[period]
+	for i := 1; i <= period; i++ {
+		sumGains += gains[i]
+		sumLosses += losses[i]
+	}
+
+	avgGain := sumGains / float64(period)
+	avgLoss := sumLosses / float64(period)
+
+	// Calculate first RSI value at index 'period'
+	if avgLoss == 0 {
+		// If avgLoss is 0, RSI is 100. If avgGain is also 0, some sources say 50, others 0 or 100.
+		// Sticking to 100 if avgLoss is 0 as per primary instruction.
+		// If both avgGain and avgLoss are zero (no price change over the period), RSI is often considered 50.
+		if avgGain == 0 {
+			rsiValues[period] = 50.0 
+		} else {
+			rsiValues[period] = 100.0
+		}
+	} else {
+		rs := avgGain / avgLoss
+		rsiValues[period] = 100 - (100 / (1 + rs))
+	}
+
+	// Calculate subsequent RSI values using smoothed average
+	for i := period + 1; i < len(data); i++ {
+		avgGain = ((avgGain * float64(period-1)) + gains[i]) / float64(period)
+		avgLoss = ((avgLoss * float64(period-1)) + losses[i]) / float64(period)
+
+		if avgLoss == 0 {
+			if avgGain == 0 {
+				rsiValues[i] = 50.0
+			} else {
+				rsiValues[i] = 100.0
+			}
+		} else {
+			rs := avgGain / avgLoss
+			rsiValues[i] = 100 - (100 / (1 + rs))
+		}
+	}
+
+	return rsiValues
+}


### PR DESCRIPTION
This commit introduces four widely used technical indicators:

1.  **Relative Strength Index (RSI)** (`rsi.go`): A momentum oscillator measuring the speed and change of price movements.
    -   Calculates based on average gains and losses over a specified period.
    -   Handles initial values with 0.0.

2.  **Moving Average Convergence Divergence (MACD)** (`macd.go`): A trend-following momentum indicator.
    -   Provides MACD line (fast EMA - slow EMA), signal line (EMA of MACD line), and histogram (MACD line - signal line).
    -   Utilizes the existing EMA function.

3.  **Bollinger Bands** (`bollinger_bands.go`): Volatility bands placed above and below a moving average.
    -   Consists of a middle band (SMA), an upper band (SMA + N std dev), and a lower band (SMA - N std dev).
    -   Uses existing SMA and RollingStd functions.
    -   Handles initial values (0.0) consistently, including when standard deviation is NaN.

4.  **Average True Range (ATR)** (`atr.go`): A measure of market volatility.
    -   Calculates True Range based on high, low, and previous close.
    -   Applies Wilder's Smoothing to the True Range values.
    -   Handles initial values with 0.0.

All indicators are added to the `indicators` package and follow existing conventions for function signatures and return types.